### PR TITLE
enable vs code debugger 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,16 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Attach to start:dev",
+      "port": 9229,
+      "restart": true,
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -13,15 +13,14 @@
   "version": "0.0.0",
   "main": "dist/index.js",
   "scripts": {
-    "start": "ts-node src/index.ts",
-    "start:dev": "ts-node-dev src/index.ts",
-    "start:prod": "tsc && node dist/index.js",
+    "start": "tsc && node dist/index.js",
+    "start:dev": "ts-node-dev --inspect=9229 --respawn --transpile-only src/index.ts",
     "build": "tsc",
     "build:watch": "tsc -w",
     "lint": "eslint . --ext .ts",
     "format": "prettier --write \"src/**/*.ts\"",
-    "deploy:global": "tsc && node dist/scripts/deploy-commands-global.js",
-    "deploy:guild": "tsc && node dist/scripts/deploy-commands-guild.js"
+    "deploy:guild": "tsc && node dist/scripts/deploy-commands-guild.js",
+    "deploy:global": "tsc && node dist/scripts/deploy-commands-global.js"
   },
   "engines": {
     "node": ">=16.15.1"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -47,7 +47,7 @@
     // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
     // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
     // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
+    "sourceMap": true /* Create source map files for emitted JavaScript files. */,
     // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
     "outDir": "dist" /* Specify an output folder for all emitted files. */,
     // "removeComments": true,                           /* Disable emitting comments. */
@@ -63,7 +63,7 @@
     // "newLine": "crlf",                                /* Set the newline character for emitting files. */
     // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
     // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
+    "noEmitOnError": true /* Disable emitting files if any type checking errors are reported. */,
     // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
     // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
     // "preserveValueImports": true,                     /* Preserve unused imported values in the JavaScript output that would otherwise be removed. */


### PR DESCRIPTION
added the ability to attach the vs code debugger to tsc-node-dev.
and removed unnecessary scripts in the package.json file.