### PR TITLE
fix pieces not loading after enabling source maps

### DIFF
--- a/src/lib/utils/pieces/strategies/strict.strategy.ts
+++ b/src/lib/utils/pieces/strategies/strict.strategy.ts
@@ -14,7 +14,9 @@ class StrictLoadStrategy implements LoadStrategy {
     const path: string = join(process.cwd(), 'dist', `${pieceName}s`);
     const files: string[] = readdirSync(path);
 
-    for (const file of files) {
+    const filteredFiles: string[] = files.filter((file) => file.endsWith('.js'));
+
+    for (const file of filteredFiles) {
       const Type: any = await this.importType(pieceName, file);
       const instance: T = new Type(container) as T;
 


### PR DESCRIPTION
fixed a bug where pieces loader loads map files in which it throws an error and stops loading other valid pieces.